### PR TITLE
fix actions convertion and handle disabled actions

### DIFF
--- a/src/ClassConfigConverter.php
+++ b/src/ClassConfigConverter.php
@@ -70,6 +70,12 @@ class ClassConfigConverter
 
     public function convert(string $fileName, string $outputDirectory): void
     {
+        $outputDirectoryResolved = realpath($outputDirectory);
+        if ($outputDirectoryResolved === false) {
+            throw new InvalidArgumentException('The output directory is invalid: '.$outputDirectory);
+        }
+        $outputDirectory = $outputDirectoryResolved;
+
         $allGrids = Yaml::parse(file_get_contents($fileName))['sylius_grid']['grids'] ?? [];
 
         if (!is_array($allGrids)) {
@@ -96,7 +102,7 @@ class ClassConfigConverter
             $new_content = $this->codeOutputter->printCode($phpCode);
 
             $newFileName = $className . '.php';
-            $newFilePath = realpath($outputDirectory . DIRECTORY_SEPARATOR . $newFileName);
+            $newFilePath = $outputDirectory . DIRECTORY_SEPARATOR . $newFileName;
             if ($this->verbose) {
                 echo "==============================$newFilePath================" . PHP_EOL;
                 echo $new_content;

--- a/src/GridBuilderCalls.php
+++ b/src/GridBuilderCalls.php
@@ -123,19 +123,6 @@ class GridBuilderCalls
     /** * @return array<Node\Expr> */
     public function convertActionsToFunctionParameters(array $actions): array
     {
-        $handleCustomGrid = function (string $actionName, array $configuration): Node {
-            $field = new Node\Expr\StaticCall(new Name('Action'), 'create', [
-                $this->convertValue($actionName),
-                $this->convertValue($configuration['type'])
-            ]);
-            $this->convertToFunctionCall($field, $configuration, 'label');
-            $this->convertToFunctionCall($field, $configuration, 'icon');
-            $this->convertToFunctionCall($field, $configuration, 'enabled');
-            $this->convertToFunctionCall($field, $configuration, 'position');
-            $this->convertToFunctionCall($field, $configuration, 'options');
-
-            return $field;
-        };
         $removedField = [];
         $field = [];
         foreach ($actions as $actionName => $actionConfiguration) {
@@ -145,20 +132,31 @@ class GridBuilderCalls
             }
             switch ($actionConfiguration['type']) {
                 case 'create':
-                    $field[] = new Node\Expr\StaticCall(new Name('CreateAction'), 'create');
+                    $currentField = new Node\Expr\StaticCall(new Name('CreateAction'), 'create');
                     break;
                 case 'show':
-                    $field[] = new Node\Expr\StaticCall(new Name('ShowAction'), 'create');
+                    $currentField = new Node\Expr\StaticCall(new Name('ShowAction'), 'create');
                     break;
                 case 'delete':
-                    $field[] = new Node\Expr\StaticCall(new Name('DeleteAction'), 'create');
+                    $currentField = new Node\Expr\StaticCall(new Name('DeleteAction'), 'create');
                     break;
                 case 'update':
-                    $field[] = new Node\Expr\StaticCall(new Name('UpdateAction'), 'create');
+                    $currentField = new Node\Expr\StaticCall(new Name('UpdateAction'), 'create');
                     break;
                 default:
-                    $field[] = $handleCustomGrid($actionName, $actionConfiguration);
+                    $currentField = new Node\Expr\StaticCall(new Name('Action'), 'create', [
+                        $this->convertValue($actionName),
+                        $this->convertValue($actionConfiguration['type'])
+                    ]);
             }
+
+            $this->convertToFunctionCall($currentField, $actionConfiguration, 'label');
+            $this->convertToFunctionCall($currentField, $actionConfiguration, 'icon');
+            $this->convertToFunctionCall($currentField, $actionConfiguration, 'enabled');
+            $this->convertToFunctionCall($currentField, $actionConfiguration, 'position');
+            $this->convertToFunctionCall($currentField, $actionConfiguration, 'options');
+
+            $field[]=$currentField;
         }
 
         return [$field, $removedField];


### PR DESCRIPTION
Fix error introduced in the previous PR #3.

* The `actions` configuration value must be an array or iterable. But the condition is always wrong if the value is an array.

* Fix convert the options for all default actions (create, edit, delete...).

* The `realpath` result is `false` if the file does not exist. This PR change the behavior to check if the output directory is ready before processing and throws an exception if the result of `realpath` is `false`.

This code has been tested on a real project with Sylius 1.12.